### PR TITLE
chore: Bump package versions in cdp-langchain chatbot example

### DIFF
--- a/cdp-langchain/examples/chatbot/package-lock.json
+++ b/cdp-langchain/examples/chatbot/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@coinbase/cdp-agentkit-core": "^0.0.7",
-        "@coinbase/cdp-langchain": "^0.0.8",
+        "@coinbase/cdp-agentkit-core": "^0.0.8",
+        "@coinbase/cdp-langchain": "^0.0.9",
         "@langchain/core": "^0.3.19",
         "@langchain/langgraph": "^0.2.21",
         "@langchain/openai": "^0.3.14",
@@ -28,21 +28,24 @@
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
     },
     "node_modules/@coinbase/cdp-agentkit-core": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@coinbase/cdp-agentkit-core/-/cdp-agentkit-core-0.0.7.tgz",
-      "integrity": "sha512-UZzes8fob0RKbHD3lQ4wSB9fnBOVxLIQYmyk3H3Yhri2vHnbVMkRGM+5kVtGF+ujhPo8tNM9q/ep1blY7spFmA==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@coinbase/cdp-agentkit-core/-/cdp-agentkit-core-0.0.8.tgz",
+      "integrity": "sha512-r7U2BrDVvGtVCUvsiV2wvtXlpdy15DWtafmjTg5iGOLJEyID9hOaREMAcs4nETL7rXXaRFtHFzdz6pY/831aSw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@coinbase/coinbase-sdk": "^0.11.0",
+        "twitter-api-v2": "^1.18.2",
         "viem": "^2.21.51",
         "zod": "^3.23.8"
       }
     },
     "node_modules/@coinbase/cdp-langchain": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@coinbase/cdp-langchain/-/cdp-langchain-0.0.8.tgz",
-      "integrity": "sha512-P6roJyCZ1uHSAeHxyWP1PIKDMfsuSwE1mvoERubKwhunu0tM4CPxRlcg/2MiNvwSQkcvn3uqZsFgVgbSPeIPVg==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@coinbase/cdp-langchain/-/cdp-langchain-0.0.9.tgz",
+      "integrity": "sha512-SfQzbNpAHoisbivWYPnHVVT51Pqgzfs2amJSHXnA8sTx+KussS7coNfdevHxnCBjyqK8SU/oNn4OT80WRJEhlA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@coinbase/cdp-agentkit-core": "^0.0.7",
+        "@coinbase/cdp-agentkit-core": "^0.0.8",
         "@coinbase/coinbase-sdk": "^0.11.0",
         "@langchain/core": "^0.3.19",
         "zod": "^3.22.4"
@@ -1724,6 +1727,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
+    "node_modules/twitter-api-v2": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/twitter-api-v2/-/twitter-api-v2-1.18.2.tgz",
+      "integrity": "sha512-ggImmoAeVgETYqrWeZy+nWnDpwgTP+IvFEc03Pitt1HcgMX+Yw17rP38Fb5FFTinuyNvS07EPtAfZ184uIyB0A==",
+      "license": "Apache-2.0"
+    },
     "node_modules/typeforce": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
@@ -1991,21 +2000,22 @@
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
     },
     "@coinbase/cdp-agentkit-core": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@coinbase/cdp-agentkit-core/-/cdp-agentkit-core-0.0.7.tgz",
-      "integrity": "sha512-UZzes8fob0RKbHD3lQ4wSB9fnBOVxLIQYmyk3H3Yhri2vHnbVMkRGM+5kVtGF+ujhPo8tNM9q/ep1blY7spFmA==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@coinbase/cdp-agentkit-core/-/cdp-agentkit-core-0.0.8.tgz",
+      "integrity": "sha512-r7U2BrDVvGtVCUvsiV2wvtXlpdy15DWtafmjTg5iGOLJEyID9hOaREMAcs4nETL7rXXaRFtHFzdz6pY/831aSw==",
       "requires": {
         "@coinbase/coinbase-sdk": "^0.11.0",
+        "twitter-api-v2": "^1.18.2",
         "viem": "^2.21.51",
         "zod": "^3.23.8"
       }
     },
     "@coinbase/cdp-langchain": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@coinbase/cdp-langchain/-/cdp-langchain-0.0.8.tgz",
-      "integrity": "sha512-P6roJyCZ1uHSAeHxyWP1PIKDMfsuSwE1mvoERubKwhunu0tM4CPxRlcg/2MiNvwSQkcvn3uqZsFgVgbSPeIPVg==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@coinbase/cdp-langchain/-/cdp-langchain-0.0.9.tgz",
+      "integrity": "sha512-SfQzbNpAHoisbivWYPnHVVT51Pqgzfs2amJSHXnA8sTx+KussS7coNfdevHxnCBjyqK8SU/oNn4OT80WRJEhlA==",
       "requires": {
-        "@coinbase/cdp-agentkit-core": "^0.0.7",
+        "@coinbase/cdp-agentkit-core": "^0.0.8",
         "@coinbase/coinbase-sdk": "^0.11.0",
         "@langchain/core": "^0.3.19",
         "zod": "^3.22.4"
@@ -3182,6 +3192,11 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+    },
+    "twitter-api-v2": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/twitter-api-v2/-/twitter-api-v2-1.18.2.tgz",
+      "integrity": "sha512-ggImmoAeVgETYqrWeZy+nWnDpwgTP+IvFEc03Pitt1HcgMX+Yw17rP38Fb5FFTinuyNvS07EPtAfZ184uIyB0A=="
     },
     "typeforce": {
       "version": "1.18.0",

--- a/cdp-langchain/examples/chatbot/package.json
+++ b/cdp-langchain/examples/chatbot/package.json
@@ -13,8 +13,8 @@
     "format-check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\""
   },
   "dependencies": {
-    "@coinbase/cdp-agentkit-core": "^0.0.7",
-    "@coinbase/cdp-langchain": "^0.0.8",
+    "@coinbase/cdp-agentkit-core": "^0.0.8",
+    "@coinbase/cdp-langchain": "^0.0.9",
     "@langchain/langgraph": "^0.2.21",
     "@langchain/openai": "^0.3.14",
     "@langchain/core": "^0.3.19",


### PR DESCRIPTION
### What changed? Why?

- Update `cdp-agentkit-core` and `cdp-langchain` package versions within cdp-langchain chatbot example

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
