### PR TITLE
chore: Fix README Use With Agent Quickstart Instructions

### DIFF
--- a/cdp-langchain/README.md
+++ b/cdp-langchain/README.md
@@ -1,6 +1,6 @@
 # CDP AgentKit Extension - Langchain Toolkit
 
-[![npm version](https://img.shields.io/npm/v/@coinbase/cdp-langchain.svg?style=flat-square)](https://www.npmjs.com/package/@coinbase/cdp-langchain) [![GitHub star chart](https://img.shields.io/github/stars/coinbase/cdp-agentkit?style=flat-square)](https://star-history.com/#coinbase/cdp-agentkit-nodejs) [![Open Issues](https://img.shields.io/github/issues-raw/coinbase/cdp-agentkit?style=flat-square)](https://github.com/coinbase/cdp-agentkit-nodejs/issues)
+[![npm version](https://img.shields.io/npm/v/@coinbase/cdp-langchain.svg?style=flat-square)](https://www.npmjs.com/package/@coinbase/cdp-langchain) [![GitHub star chart](https://img.shields.io/github/stars/coinbase/cdp-agentkit-nodejs?style=flat-square)](https://star-history.com/#coinbase/cdp-agentkit-nodejs) [![Open Issues](https://img.shields.io/github/issues-raw/coinbase/cdp-agentkit-nodejs?style=flat-square)](https://github.com/coinbase/cdp-agentkit-nodejs/issues)
 
 CDP integration with Langchain to enable agentic workflows using the core primitives defined in `cdp-agentkit-core`. This toolkit contains tools that enable an LLM agent to interact with the [Coinbase Developer Platform](https://docs.cdp.coinbase.com/). The toolkit provides a wrapper around the CDP SDK, allowing agents to perform onchain operations like transfers, trades, and smart contract interactions.
 
@@ -63,6 +63,11 @@ The toolkit provides the following tools:
 12. **wow_sell_token** - Sell [Zora Wow](https://wow.xyz/) ERC-20 memecoin for ETH
 
 ### Using with an Agent
+
+#### Additional Installations
+```bash
+npm install @langchain/langgraph @langchain/openai
+```
 
 ```typescript
 import { ChatOpenAI } from "@langchain/openai";

--- a/twitter-langchain/README.md
+++ b/twitter-langchain/README.md
@@ -33,7 +33,8 @@ export TWITTER_ACCESS_TOKEN_SECRET=<your-access-token-secret>
 ### Basic Setup
 
 ```typescript
-import { TwitterAgentkit, TwitterToolkit } from "@coinbase/twitter-langchain";
+import { TwitterAgentkit } from "@coinbase/cdp-agentkit-core";
+import { TwitterToolkit } from "@coinbase/twitter-langchain";
 
 // Initialize Twitter AgentKit
 const agentkit = new TwitterAgentkit();
@@ -55,6 +56,11 @@ The toolkit provides the following tools:
 3. **post_tweet_reply** - Post a reply to a tweet on Twitter
 
 ### Using with an Agent
+
+#### Additional Installations
+```bash
+npm install @langchain/langgraph @langchain/openai
+```
 
 ```typescript
 import { ChatOpenAI } from "@langchain/openai";


### PR DESCRIPTION
### What changed? Why?
- Add LangGraph and OpenAI installation instructions to README `Use with Agent` section
- Fix README badges 

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
