### PR TITLE
refactor: use `ZodString.min(1)` instead of deprecated `ZodString.nonempty()`

### DIFF
--- a/cdp-agentkit-core/CHANGELOG.md
+++ b/cdp-agentkit-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Refactor
+
+- Use `ZodString.min(1)` instead of deprecated `ZodString.nonempty()`
+
 ## [0.0.8] - 2024-12-09
 
 ### Added

--- a/cdp-agentkit-core/src/actions/cdp/social/twitter/account_mentions.ts
+++ b/cdp-agentkit-core/src/actions/cdp/social/twitter/account_mentions.ts
@@ -28,7 +28,7 @@ export const AccountMentionsInput = z
   .object({
     userId: z
       .string()
-      .nonempty("Account ID is required.")
+      .min(1, "Account ID is required.")
       .describe("The Twitter (X) user id to return mentions for"),
   })
   .strip()

--- a/cdp-agentkit-core/src/twitter_agentkit.ts
+++ b/cdp-agentkit-core/src/twitter_agentkit.ts
@@ -9,19 +9,19 @@ export const TwitterAgentkitOptions = z
   .object({
     apiKey: z
       .string()
-      .nonempty("The Twitter (X) API key is required")
+      .min(1, "The Twitter (X) API key is required")
       .describe("The Twitter (X) API key"),
     apiSecret: z
       .string()
-      .nonempty("The Twitter (X) API secret is required")
+      .min(1, "The Twitter (X) API secret is required")
       .describe("The Twitter (X) API secret"),
     accessToken: z
       .string()
-      .nonempty("The Twitter (X) access token is required")
+      .min(1, "The Twitter (X) access token is required")
       .describe("The Twitter (X) access token"),
     accessTokenSecret: z
       .string()
-      .nonempty("The Twitter (X) access token secret is required")
+      .min(1, "The Twitter (X) access token secret is required")
       .describe("The Twitter (X) access token secret"),
   })
   .strip()
@@ -33,19 +33,19 @@ export const TwitterAgentkitOptions = z
 const EnvSchema = z.object({
   TWITTER_API_KEY: z
     .string()
-    .nonempty("TWITTER_API_KEY is required")
+    .min(1, "TWITTER_API_KEY is required")
     .describe("The Twitter (X) API key"),
   TWITTER_API_SECRET: z
     .string()
-    .nonempty("TWITTER_API_SECRET is required")
+    .min(1, "TWITTER_API_SECRET is required")
     .describe("The Twitter (X) API secret"),
   TWITTER_ACCESS_TOKEN: z
     .string()
-    .nonempty("TWITTER_ACCESS_TOKEN is required")
+    .min(1, "TWITTER_ACCESS_TOKEN is required")
     .describe("The Twitter (X) access token"),
   TWITTER_ACCESS_TOKEN_SECRET: z
     .string()
-    .nonempty("TWITTER_ACCESS_TOKEN_SECRET is required")
+    .min(1, "TWITTER_ACCESS_TOKEN_SECRET is required")
     .describe("The Twitter (X) access token secret"),
 });
 


### PR DESCRIPTION
### What changed? Why?

Hello, `ZodString.nonempty()` is deprecated since awhile as per this discussion https://github.com/colinhacks/zod/discussions/2847 and `ZodString.min(1)` should be used instead.

It also pops up on the LSP.

![image](https://github.com/user-attachments/assets/761ce6b2-2898-498c-90c2-d5df0b46c941)

So this PR basically replaces all `nonempty()` by `min(1)` and still preserves error initial error messages.