### PR TITLE
chore: bump cdp langchain deps

### DIFF
--- a/cdp-langchain/CHANGELOG.md
+++ b/cdp-langchain/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Bump `@coinbase/cdp-agentkit-core` dependency to `0.0.10`
+
 ## [0.0.10] - 2025-01-08
 
 ### Added

--- a/cdp-langchain/package.json
+++ b/cdp-langchain/package.json
@@ -38,7 +38,7 @@
     "langchain"
   ],
   "dependencies": {
-    "@coinbase/cdp-agentkit-core": "^0.0.9",
+    "@coinbase/cdp-agentkit-core": "^0.0.10",
     "@coinbase/coinbase-sdk": "^0.13.0",
     "@langchain/core": "^0.3.19",
     "zod": "^3.22.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,25 +54,13 @@
       "version": "0.0.10",
       "license": "Apache-2.0",
       "dependencies": {
-        "@coinbase/cdp-agentkit-core": "^0.0.9",
+        "@coinbase/cdp-agentkit-core": "^0.0.10",
         "@coinbase/coinbase-sdk": "^0.13.0",
         "@langchain/core": "^0.3.19",
         "zod": "^3.22.4"
       },
       "peerDependencies": {
         "@coinbase/coinbase-sdk": "^0.13.0"
-      }
-    },
-    "cdp-langchain/node_modules/@coinbase/cdp-agentkit-core": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@coinbase/cdp-agentkit-core/-/cdp-agentkit-core-0.0.9.tgz",
-      "integrity": "sha512-COmouMalx90AnwsXH+s7EV+BXzxOwoNCy1nPxoEzGo/hHrTn1IMtT3WO9iKBbffEZNXAKDCrOXcyS6+NjSKGnw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@coinbase/coinbase-sdk": "^0.13.0",
-        "twitter-api-v2": "^1.18.2",
-        "viem": "^2.21.51",
-        "zod": "^3.23.8"
       }
     },
     "node_modules/@adraffy/ens-normalize": {


### PR DESCRIPTION
### What changed? Why?
- Bump `@coinbase/cdp-agentkit-core` to `0.0.10`


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
