### PR TITLE
chore: bump twitter langchain deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8077,7 +8077,7 @@
       "name": "@coinbase/twitter-langchain",
       "version": "0.0.7",
       "dependencies": {
-        "@coinbase/cdp-agentkit-core": "^0.0.9",
+        "@coinbase/cdp-agentkit-core": "^0.0.10",
         "@langchain/core": "^0.3.19",
         "twitter-api-v2": "^1.18.2",
         "zod": "^3.22.4"
@@ -8088,18 +8088,6 @@
     },
     "twitter-langchain/File:../cdp-agentkit-core": {
       "extraneous": true
-    },
-    "twitter-langchain/node_modules/@coinbase/cdp-agentkit-core": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@coinbase/cdp-agentkit-core/-/cdp-agentkit-core-0.0.9.tgz",
-      "integrity": "sha512-COmouMalx90AnwsXH+s7EV+BXzxOwoNCy1nPxoEzGo/hHrTn1IMtT3WO9iKBbffEZNXAKDCrOXcyS6+NjSKGnw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@coinbase/coinbase-sdk": "^0.13.0",
-        "twitter-api-v2": "^1.18.2",
-        "viem": "^2.21.51",
-        "zod": "^3.23.8"
-      }
     },
     "twitter-langchain/node_modules/@langchain/core": {
       "version": "0.3.21",

--- a/twitter-langchain/CHANGELOG.md
+++ b/twitter-langchain/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Bump `@coinbase/cdp-agentkit-core` dependency to `0.0.10`
+
 ## [0.0.7] - 2025-01-08
 
 ### Added

--- a/twitter-langchain/package.json
+++ b/twitter-langchain/package.json
@@ -35,7 +35,7 @@
     "langchain"
   ],
   "dependencies": {
-    "@coinbase/cdp-agentkit-core": "^0.0.9",
+    "@coinbase/cdp-agentkit-core": "^0.0.10",
     "@langchain/core": "^0.3.19",
     "twitter-api-v2": "^1.18.2",
     "zod": "^3.22.4"


### PR DESCRIPTION
### What changed? Why?
- Bump `@coinbase/cdp-agentkit-core` to `0.0.10`


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
