### PR TITLE
chore: Release cdp/twitter-langchain for core 0.0.11 bump

### DIFF
--- a/cdp-langchain/CHANGELOG.md
+++ b/cdp-langchain/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## [0.0.12] - 2025-01-13
+
+### Added
+- Bump `@coinbase/cdp-agentkit-core` dependency to `0.0.11`
+
 ## [0.0.11] - 2025-01-09
 
 ### Added

--- a/cdp-langchain/package.json
+++ b/cdp-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cdp-langchain",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Langchain Toolkit extension of CDP Agentkit",
   "repository": "https://github.com/coinbase/cdp-agentkit-nodejs",
   "author": "Coinbase Inc.",
@@ -40,7 +40,7 @@
     "langchain"
   ],
   "dependencies": {
-    "@coinbase/cdp-agentkit-core": "^0.0.10",
+    "@coinbase/cdp-agentkit-core": "^0.0.11",
     "@coinbase/coinbase-sdk": "^0.13.0",
     "@langchain/core": "^0.3.19",
     "zod": "^3.22.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,27 +51,16 @@
     },
     "cdp-langchain": {
       "name": "@coinbase/cdp-langchain",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "license": "Apache-2.0",
       "dependencies": {
-        "@coinbase/cdp-agentkit-core": "^0.0.10",
+        "@coinbase/cdp-agentkit-core": "^0.0.11",
         "@coinbase/coinbase-sdk": "^0.13.0",
         "@langchain/core": "^0.3.19",
         "zod": "^3.22.4"
       },
       "peerDependencies": {
         "@coinbase/coinbase-sdk": "^0.13.0"
-      }
-    },
-    "cdp-langchain/node_modules/@coinbase/cdp-agentkit-core": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@coinbase/cdp-agentkit-core/-/cdp-agentkit-core-0.0.10.tgz",
-      "integrity": "sha512-EFTaCkCd1445B4jq3LxVJaqw+r4BrwyjTAOoEabKrv9BycCPgS7fPRLuuugmnJRbSEtlG90NbsRZ7B6YkQRJ/g==",
-      "dependencies": {
-        "@coinbase/coinbase-sdk": "^0.13.0",
-        "twitter-api-v2": "^1.18.2",
-        "viem": "^2.21.51",
-        "zod": "^3.23.8"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -8086,9 +8075,9 @@
     },
     "twitter-langchain": {
       "name": "@coinbase/twitter-langchain",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
-        "@coinbase/cdp-agentkit-core": "^0.0.10",
+        "@coinbase/cdp-agentkit-core": "^0.0.11",
         "@langchain/core": "^0.3.19",
         "twitter-api-v2": "^1.18.2",
         "zod": "^3.22.4"
@@ -8099,17 +8088,6 @@
     },
     "twitter-langchain/File:../cdp-agentkit-core": {
       "extraneous": true
-    },
-    "twitter-langchain/node_modules/@coinbase/cdp-agentkit-core": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@coinbase/cdp-agentkit-core/-/cdp-agentkit-core-0.0.10.tgz",
-      "integrity": "sha512-EFTaCkCd1445B4jq3LxVJaqw+r4BrwyjTAOoEabKrv9BycCPgS7fPRLuuugmnJRbSEtlG90NbsRZ7B6YkQRJ/g==",
-      "dependencies": {
-        "@coinbase/coinbase-sdk": "^0.13.0",
-        "twitter-api-v2": "^1.18.2",
-        "viem": "^2.21.51",
-        "zod": "^3.23.8"
-      }
     },
     "twitter-langchain/node_modules/@langchain/core": {
       "version": "0.3.21",

--- a/twitter-langchain/CHANGELOG.md
+++ b/twitter-langchain/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## [0.0.9] - 2025-01-13
+
+### Added
+- Bump `@coinbase/cdp-agentkit-core` dependency to `0.0.11`
+
 ## [0.0.8] - 2025-01-09
 
 ### Added

--- a/twitter-langchain/package.json
+++ b/twitter-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/twitter-langchain",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Twitter (X) langchain Toolkit extension of CDP Agentkit",
   "repository": "https://github.com/coinbase/cdp-agentkit-nodejs",
   "main": "dist/index.js",
@@ -35,7 +35,7 @@
     "langchain"
   ],
   "dependencies": {
-    "@coinbase/cdp-agentkit-core": "^0.0.10",
+    "@coinbase/cdp-agentkit-core": "^0.0.11",
     "@langchain/core": "^0.3.19",
     "twitter-api-v2": "^1.18.2",
     "zod": "^3.22.4"


### PR DESCRIPTION
### What changed? Why?
- Release `cdp-langchain` `0.0.12`
- Release `twitter-langchain` `0.0.9`

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
