### PR TITLE
chore: Bump example chatbot deps core 0.0.11

### DIFF
--- a/cdp-langchain/examples/chatbot/package-lock.json
+++ b/cdp-langchain/examples/chatbot/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@coinbase/cdp-agentkit-core": "^0.0.10",
-        "@coinbase/cdp-langchain": "^0.0.11",
+        "@coinbase/cdp-agentkit-core": "^0.0.11",
+        "@coinbase/cdp-langchain": "^0.0.12",
         "@langchain/core": "^0.3.19",
         "@langchain/langgraph": "^0.2.21",
         "@langchain/openai": "^0.3.14",
@@ -28,10 +28,9 @@
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
     },
     "node_modules/@coinbase/cdp-agentkit-core": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@coinbase/cdp-agentkit-core/-/cdp-agentkit-core-0.0.10.tgz",
-      "integrity": "sha512-EFTaCkCd1445B4jq3LxVJaqw+r4BrwyjTAOoEabKrv9BycCPgS7fPRLuuugmnJRbSEtlG90NbsRZ7B6YkQRJ/g==",
-      "license": "Apache-2.0",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@coinbase/cdp-agentkit-core/-/cdp-agentkit-core-0.0.11.tgz",
+      "integrity": "sha512-DqhJw4alO1cKWQgVrUv669DV8Jt9DMuZSKZTesVyuoC8b9LV9WHep6c43Eu957nqx+LU1+2hPVLYCdma5iZDpA==",
       "dependencies": {
         "@coinbase/coinbase-sdk": "^0.13.0",
         "twitter-api-v2": "^1.18.2",
@@ -40,12 +39,11 @@
       }
     },
     "node_modules/@coinbase/cdp-langchain": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@coinbase/cdp-langchain/-/cdp-langchain-0.0.11.tgz",
-      "integrity": "sha512-RqnViEuhPHa0uTWTA08R6G7JIco8s4hPiX/ChbeXC0q4h+0cGATC1bJxIW73NMJXEZfLPitM0871UZPdnDXxuw==",
-      "license": "Apache-2.0",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@coinbase/cdp-langchain/-/cdp-langchain-0.0.12.tgz",
+      "integrity": "sha512-UnBVIf9eUNNsby9GMV7HHafiv79usyL+FEssn3go/2OP6WkLnX6F8/TNRbQ+SIr9t3T+gYrlUxFK0taHQdm42g==",
       "dependencies": {
-        "@coinbase/cdp-agentkit-core": "^0.0.10",
+        "@coinbase/cdp-agentkit-core": "^0.0.11",
         "@coinbase/coinbase-sdk": "^0.13.0",
         "@langchain/core": "^0.3.19",
         "zod": "^3.22.4"
@@ -2056,9 +2054,9 @@
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
     },
     "@coinbase/cdp-agentkit-core": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@coinbase/cdp-agentkit-core/-/cdp-agentkit-core-0.0.10.tgz",
-      "integrity": "sha512-EFTaCkCd1445B4jq3LxVJaqw+r4BrwyjTAOoEabKrv9BycCPgS7fPRLuuugmnJRbSEtlG90NbsRZ7B6YkQRJ/g==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@coinbase/cdp-agentkit-core/-/cdp-agentkit-core-0.0.11.tgz",
+      "integrity": "sha512-DqhJw4alO1cKWQgVrUv669DV8Jt9DMuZSKZTesVyuoC8b9LV9WHep6c43Eu957nqx+LU1+2hPVLYCdma5iZDpA==",
       "requires": {
         "@coinbase/coinbase-sdk": "^0.13.0",
         "twitter-api-v2": "^1.18.2",
@@ -2067,11 +2065,11 @@
       }
     },
     "@coinbase/cdp-langchain": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@coinbase/cdp-langchain/-/cdp-langchain-0.0.11.tgz",
-      "integrity": "sha512-RqnViEuhPHa0uTWTA08R6G7JIco8s4hPiX/ChbeXC0q4h+0cGATC1bJxIW73NMJXEZfLPitM0871UZPdnDXxuw==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@coinbase/cdp-langchain/-/cdp-langchain-0.0.12.tgz",
+      "integrity": "sha512-UnBVIf9eUNNsby9GMV7HHafiv79usyL+FEssn3go/2OP6WkLnX6F8/TNRbQ+SIr9t3T+gYrlUxFK0taHQdm42g==",
       "requires": {
-        "@coinbase/cdp-agentkit-core": "^0.0.10",
+        "@coinbase/cdp-agentkit-core": "^0.0.11",
         "@coinbase/coinbase-sdk": "^0.13.0",
         "@langchain/core": "^0.3.19",
         "zod": "^3.22.4"

--- a/cdp-langchain/examples/chatbot/package.json
+++ b/cdp-langchain/examples/chatbot/package.json
@@ -13,8 +13,8 @@
     "format-check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\""
   },
   "dependencies": {
-    "@coinbase/cdp-agentkit-core": "^0.0.10",
-    "@coinbase/cdp-langchain": "^0.0.11",
+    "@coinbase/cdp-agentkit-core": "^0.0.11",
+    "@coinbase/cdp-langchain": "^0.0.12",
     "@langchain/langgraph": "^0.2.21",
     "@langchain/openai": "^0.3.14",
     "@langchain/core": "^0.3.19",


### PR DESCRIPTION
### What changed? Why?
- Bump packages in example chatbot
  -  `"@coinbase/cdp-agentkit-core": "^0.0.11",`
  - ` "@coinbase/cdp-langchain": "^0.0.12",`

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
